### PR TITLE
Add package grunt task 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 /node_modules
 /build
+/dist
+*.pem

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -67,10 +67,10 @@ module.exports = function(grunt) {
     grunt.loadTasks('tasks');
 
     // Register the default task
-    grunt.registerTask('build', ['jshint:grunt', 'jshint:tests', 'core', 'chrome', 'firefox', 'opera']);
+    grunt.registerTask('build', 'Lint, test and build everything', ['jshint:grunt', 'jshint:tests', 'core', 'chrome', 'firefox', 'opera']);
 
     // Register alais tasks so tooling can be switched
-    grunt.registerTask('test', 'jasmine_node');
-    grunt.registerTask('lint', 'jshint');
+    grunt.registerTask('test', 'Run all unit tests', 'jasmine_node');
+    grunt.registerTask('lint', 'Lint all project files', 'jshint');
 
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-newer": "~1.1.1",
-    "grunt-jasmine-node": "~0.3.1"
+    "grunt-jasmine-node": "~0.3.1",
+    "archiver": "~0.15.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,18 @@ grunt package:opera
 grunt package:firefox
 ```
 
+### Private keys for Chromium
+
+When packaging for the first time, both Chrome and Opera will export a private key (a `.pem` file) to the `/config` directory. You'll need to keep these files safe as they will be required when you release future versions of your extension. _NEVER_ add these files to your public repos.
+
+If your moving an existing extension to Fuse you can copy your private key files here:
+
+* For Chrome: `/config/chrome.pem`
+* For Opera: `/config/opera.pem`
+
+_NOTE: Opera will fail to package an extension if it is already running. This is a known issue that Opera developers are working on._
+_NOTE: Opera will fail to terminate when packaging with an existing private key. This causes the extension package task to hang. To work around this you'll need to terminate Opera manually. A bug has been submitted (DNA-44534)._
+
 
 ## Project structure
 

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,22 @@ CSS:
 * Chrome / Opera: `src/chromium/css/main.css` 
 
 
+## Packaging your extension
+
+Fuse can package your extension into a standalone installable files. To package everything, ensure your have run the relevant build tasks and then run:
+
+```
+grunt package
+```
+
+If you need to package individual extensions:
+
+```
+grunt package:chrome
+grunt package:opera
+grunt package:firefox
+```
+
 
 ## Project structure
 

--- a/tasks/chrome.js
+++ b/tasks/chrome.js
@@ -61,7 +61,10 @@ module.exports = function(grunt) {
                 method: 'chrome',
                 src: 'build/chrome',
                 dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.crx',
-                bin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+                bin: [
+                    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+                    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
+                ],
                 privateKeyFile: 'config/chrome.pem'
             }
         }

--- a/tasks/chrome.js
+++ b/tasks/chrome.js
@@ -55,6 +55,15 @@ module.exports = function(grunt) {
                 files: 'src/chromium/**/*.js',
                 tasks: ['newer:jshint:chrome', 'newer:copy:chrome']
             }
+        },
+        package: {
+            chrome: {
+                method: 'chrome',
+                src: 'build/chrome',
+                dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.crx',
+                bin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+                privateKeyFile: 'config/chrome.pem'
+            }
         }
     });
 

--- a/tasks/firefox.js
+++ b/tasks/firefox.js
@@ -67,6 +67,13 @@ module.exports = function(grunt) {
                 files: ['src/firefox/**/*.js'],
                 tasks: ['newer:jshint:firefox', 'newer:copy:firefox']
             }
+        },
+        package: {
+            firefox: {
+                method: 'zip',
+                src: 'build/firefox',
+                dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.xpi'
+            }
         }
     });
 

--- a/tasks/opera.js
+++ b/tasks/opera.js
@@ -61,7 +61,10 @@ module.exports = function(grunt) {
                 method: 'chrome',
                 src: 'build/opera',
                 dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.nex',
-                bin: '/Applications/Opera.app/Contents/MacOS/Opera',
+                bin: [
+                    '/Applications/Opera.app/Contents/MacOS/Opera',
+                    'C:\\Program Files\\Opera\\*\\opera.exe'
+                ],
                 privateKeyFile: 'config/opera.pem'
             }
         }

--- a/tasks/opera.js
+++ b/tasks/opera.js
@@ -55,10 +55,19 @@ module.exports = function(grunt) {
                 files: 'src/chromium/**/*.js',
                 tasks: ['newer:jshint:opera', 'newer:copy:opera']
             }
+        },
+        package: {
+            opera: {
+                method: 'chrome',
+                src: 'build/opera',
+                dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.nex',
+                bin: '/Applications/Opera.app/Contents/MacOS/Opera',
+                privateKeyFile: 'config/opera.pem'
+            }
         }
     });
 
-    grunt.registerTask('opera', 'Builds the opera extension', function() {
+    grunt.registerTask('opera', 'Builds the Opera extension', function() {
         this.requires('core');
         grunt.task.run(['jshint:opera', 'copy:opera']);
     });

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -1,0 +1,121 @@
+/* jshint node: true */
+
+'use strict';
+
+module.exports = function(grunt) {
+    var exec = require('child_process').exec,
+        fs = require('fs'),
+        path = require('path'),
+        archiver = require('archiver');
+
+
+    /**
+     * Check the directory of the passed filepath exists and create it if
+     * it doesn't
+     */
+    function ensureDirExists(filepath) {
+        var dir = path.dirname(filepath);
+        if (!grunt.file.isDir(dir)) {
+            grunt.file.mkdir(dir);
+            return true;
+        }
+    }
+
+    /**
+     * Packages the passed directory of files in to a zip archive and 
+     * writes it to disk
+     */
+    function packageZip(src, dest, done) {
+        var output = fs.createWriteStream(dest),
+            archive = archiver('zip');
+
+        output.on('close', function () {
+            grunt.log.ok('Saved package: ' + dest);
+            done();
+        });
+
+        archive.on('error', function (err) {
+            grunt.log.error(err);
+            done(false);
+        });
+
+        archive.pipe(output);
+
+        archive.bulk([{
+            expand: true,
+            cwd: src,
+            src: ['**/*']
+        }]);
+
+        archive.finalize();
+    }
+
+
+    /**
+     * Packages an extension via the browser CLI. This method is used by
+     * Chrome and Opera.
+     */
+    function packageChrome(data, done) {
+        var cmd, destExt;
+
+        // Check the source files exist
+        if (!grunt.file.exists(data.src)) {
+            grunt.log.error('Source files not found');
+            return done(false);
+        }
+
+        // Check the application exists
+        if (!grunt.file.exists(data.bin)) {
+            grunt.log.error('Application binary not found');
+            return done(false);
+        }
+
+        // get the dest extension
+        destExt = path.extname(data.dest);
+
+        // build the command
+        cmd = data.bin.replace(/ /g, '\\ ') + ' --pack-extension=' + data.src;
+ 
+        // If a private key file exists, use it
+        if (data.privateKeyFile && grunt.file.exists(data.privateKeyFile)) {
+            grunt.log.ok('Private key file found.');
+            cmd += ' --pack-extension-key=' + data.privateKeyFile;
+        } else {
+            grunt.log.warn('No private key file found. A new one will be created.');
+        }
+
+        // execute the command and copy packaged files to final location
+        exec(cmd, {}, function (err) {
+            if (err) {
+                grunt.log.error(err);
+            } else {
+                // ensure the dest directory exists
+                ensureDirExists(data.dest);
+
+                // move the package into the dest directoy
+                fs.renameSync(data.src + destExt, data.dest);
+
+                // if a private key file was created, move that too
+                if (grunt.file.exists(data.src + '.pem')) {
+                    fs.renameSync(data.src + '.pem', data.privateKeyFile);
+                    grunt.log.ok('Saved private key file: ' + data.privateKeyFile);
+                }
+                grunt.log.ok('Saved package: ' + data.dest);
+            }
+            done(!err);
+        });
+    }
+
+
+    /**
+     * Register the `package` task
+     */
+    grunt.registerMultiTask('package', 'Package extensions for installation', function () {
+        var done = this.async();
+        if (this.data.method === 'chrome') {
+            packageChrome(this.data, done);
+        } else if (this.data.method === 'zip') {
+            packageZip(this.data.src, this.data.dest, done);
+        }
+    });
+};


### PR DESCRIPTION
This update allows Fuse to package a built extension into a standalone file ready for installing in a browser.

To package, run

```
grunt package                      // package all
grunt package:{{browser}}          // package a specific browser extension
```
